### PR TITLE
feat: add BEdita API proxy for GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export default defineNuxtConfig({
     apiBaseUrl: 'https://api-bedita.mydomain.com', // required
     apiKey: '<bedita-api-key>', // required
     endpoints: ['auth', 'signup'], // API endpoints added to app
-    proxyEndpoints: [], // endpoints proxied to BEdita API as is
+    proxyEndpoints: [], // endpoints proxied to BEdita API as is (by default all GET requests are proxied)
     recaptcha: {
       enabled: true, // default true
       siteKey: '<recaptcha-site-key>', // required if recaptcha is enabled

--- a/playground/pages/api-proxy.vue
+++ b/playground/pages/api-proxy.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <h2>BEdita API proxy Page</h2>
+    <p>List of BEdita objects:</p>
+    <ul>
+      <li v-for="obj, key in data?.formattedData?.data" :key="key">{{ obj?.attributes?.title }}</li>
+    </ul>
+    {{ error }}
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ApiResponseBodyList } from '@atlasconsulting/nuxt-bedita';
+
+const { data, error } = useFetch<ApiResponseBodyList>('/api/bedita/objects');
+
+</script>

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -5,5 +5,6 @@
     <li><NuxtLink to="/signup-activation">Signup Activation</NuxtLink></li>
     <li><NuxtLink to="/forgot-password">Forgot password</NuxtLink></li>
     <li><NuxtLink to="/optout">Opt-out</NuxtLink></li>
+    <li><NuxtLink to="/api-proxy">BEdita API proxy page</NuxtLink></li>
   </ul>
 </template>

--- a/src/runtime/server/api/bedita/api-proxy.get.ts
+++ b/src/runtime/server/api/bedita/api-proxy.get.ts
@@ -1,0 +1,25 @@
+import { useRuntimeConfig } from '#imports';
+import { createError, defineEventHandler, getQuery } from 'h3';
+import { beditaClient, handleBeditaApiError } from '../../utils/bedita-client';
+import type { ApiResponseBodyResource, ApiResponseBodyList, ProxyEndpointConf } from '../../../types';
+import { type ApiResponseBodyError} from '@atlasconsulting/bedita-sdk';
+
+export default defineEventHandler(async (event): Promise<ApiResponseBodyResource | ApiResponseBodyList | Record<string, unknown> | ApiResponseBodyError> => {
+  const config = useRuntimeConfig();
+  const path = event.path.replace(/^\/api\/bedita/, '') || '';
+  const allowedEndpoints: ProxyEndpointConf[] = config.bedita.proxyEndpoints.filter((e: ProxyEndpointConf) => e.methods.includes('*') || e.methods.includes('GET'));
+  if (!allowedEndpoints.length || allowedEndpoints.filter(endpoint => endpoint.path === '*' || path.startsWith(endpoint.path)).length === 0) {
+    throw createError({
+      statusCode: 404,
+    });
+  }
+
+  try {
+    const client = await beditaClient(event);
+    const response = await client.get(path, { params: getQuery(event) });
+
+    return { ...response.data, formattedData: response?.formattedData || {} };
+  } catch (error) {
+    return handleBeditaApiError(event, error);
+  }
+});

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -42,3 +42,10 @@ export type SignupBeditaBody = {
   name?: string,
   surname?: string,
 } & Record<string, any>
+
+export type EndpointConf = 'auth' | 'signup';
+
+export type ProxyEndpointConf = {
+  path: string,
+  methods: ('GET' | 'POST' | 'PATCH' | 'DELETE' | '*')[],
+};


### PR DESCRIPTION
Add a way to proxy requests to BEdita API. At the moment only GET requests are allowed.
By default all GET requests will proxied but it is possible to limit the requests through `nuxt.config`

```ts
export default defineNuxtConfig({
  modules: ['@atlasconsulting/nuxt-bedita'],
  bedita: {
    apiBaseUrl: '',
    apiKey: '',
    // other conf
    proxyEndpoints: [
      {
        path: '/documents', // proxy only /api/bedita/documents to BEdita /documents, all other requests will return 404
        methods: ['GET'],
      }
    ],
  },
})
```