### PR TITLE
fix: add type annotation in useBeditaSignup()

### DIFF
--- a/src/runtime/composables/useBeditaSignup.ts
+++ b/src/runtime/composables/useBeditaSignup.ts
@@ -1,14 +1,17 @@
 import { useRecaptcha } from '../composables/useRecaptcha';
-import { useRoute, useFetch } from '#imports';
+import { useRoute } from '#imports';
+import type { AsyncData } from '#app';
 import type { SignupBeditaBody } from '../types';
 import { RecaptchaActions } from '../utils/recaptcha-helpers';
+import type { ApiResponseBodyError, JsonApiResourceObject } from '@atlasconsulting/bedita-sdk';
+import type { FetchError } from 'ofetch';
 
 export const useBeditaSignup = () => {
   const { executeRecaptcha } = useRecaptcha();
 
   const signup = async (data: SignupBeditaBody) => {
     const recaptcha_token = await executeRecaptcha(RecaptchaActions.SIGNUP);
-    return await $fetch('/api/bedita/signup', {
+    return await $fetch<JsonApiResourceObject>('/api/bedita/signup', {
       method: 'POST',
       body: {
         ...data,
@@ -17,10 +20,10 @@ export const useBeditaSignup = () => {
     });
   };
 
-  const signupActivation = async (uuid?: string, server?: boolean) => {
+  const signupActivation = (uuid?: string, server?: boolean): AsyncData<{ activated: true;} | null, FetchError<ApiResponseBodyError> | null> => {
     const route = useRoute();
 
-    return await useFetch('/api/bedita/signup/activation', {
+    return useFetch('/api/bedita/signup/activation', {
       method:'POST',
       body: { uuid: uuid || route.query?.uuid },
       server,

--- a/src/runtime/server/api/bedita/signup/activation.post.ts
+++ b/src/runtime/server/api/bedita/signup/activation.post.ts
@@ -1,7 +1,8 @@
 import { defineEventHandler, readBody } from 'h3';
 import { beditaApiClient, handleBeditaApiError } from '../../../utils/bedita-api-client';
+import type { ApiResponseBodyError } from '@atlasconsulting/bedita-sdk';
 
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async (event): Promise<{ activated: true; } | ApiResponseBodyError> => {
   try {
     const body = await readBody(event);
     const client = await beditaApiClient(event);

--- a/src/runtime/server/api/bedita/signup/signup.post.ts
+++ b/src/runtime/server/api/bedita/signup/signup.post.ts
@@ -2,9 +2,9 @@ import { defineEventHandler, readBody } from 'h3';
 import { recaptchaVerifyToken } from '../../../utils/recaptcha';
 import { beditaApiClient, handleBeditaApiError } from '../../../utils/bedita-api-client';
 import { RecaptchaActions } from '../../../../utils/recaptcha-helpers';
-import { type JsonApiResourceObject } from '@atlasconsulting/bedita-sdk';
+import { type ApiResponseBodyError, type JsonApiResourceObject } from '@atlasconsulting/bedita-sdk';
 
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async (event): Promise<JsonApiResourceObject | ApiResponseBodyError> => {
   try {
     const body = await readBody(event);
 


### PR DESCRIPTION
Add type annotation to avoid that `prepack` fails with error like

```
The inferred type of 'useBeditaSignup' cannot be named without a reference to '../../../node_modules/nitropack/dist'. This is likely not portable. A type annotation is necessary.
```