### PR TITLE
fix: auto import SSR utility functions

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -7,6 +7,7 @@ import {
   addRouteMiddleware,
   logger,
   addTypeTemplate,
+  addImports,
 } from '@nuxt/kit';
 import { type NitroEventHandler } from 'nitropack';
 import { defu } from 'defu';
@@ -198,11 +199,22 @@ export default defineNuxtModule<ModuleOptions>({
 
     /*
      ********************************
-     * Composables and client utils *
+     * Composables and SSR utils    *
      ********************************
      */
     addImportsDir(resolver.resolve('./runtime/utils'));
     addImportsDir(resolver.resolve('./runtime/composables'));
+    // imports to use for example in route middlewares (server side)
+    addImports([
+      {
+        from: resolver.resolve('./runtime/server/utils/session'),
+        name: 'getSessionConfig',
+      },
+      {
+        from: resolver.resolve('./runtime/server/utils/bedita-api-client'),
+        name: 'beditaApiClient',
+      },
+    ]);
 
     /*
      *****************


### PR DESCRIPTION
This PR add auto imports for `getSessionConfig()` and `beditaApiClient()` to allow to use it in SSR context as in server side of route middlewares.

Example:

```ts
export default defineNuxtRouteMiddleware(async (to, from) => {
  if (process.server) {
    const e = useRequestEvent();
    if (!e) {
      return;
    }
    const client = await beditaApiClient(e);
    
    // do stuff with BEdita API client
  }
})
```