### PR TITLE
feat: add "redirect" query string in sign-in redirect

### DIFF
--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -26,9 +26,14 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
   const { user, isLogged } = useBeditaAuth();
 
+  const redirectObject =  {
+    path: config.public.bedita.auth.unauthenticatedRedirect,
+    query: { redirect: to.fullPath },
+  };
+
   // if auth is required and user is not logged, redirect to login page
   if (config.public.bedita.auth.required && !isLogged.value) {
-    return navigateTo(config.public.bedita.auth.unauthenticatedRedirect);
+    return navigateTo(redirectObject);
   }
 
   // check if user has required roles to access the route
@@ -40,7 +45,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
   // There are roles guard for this route, but user is not logged
   if (!isLogged.value) {
-    return navigateTo(config.public.bedita.auth.unauthenticatedRedirect);
+    return navigateTo(redirectObject);
   }
 
   // if user has at least a role for the guard, then user is authorized


### PR DESCRIPTION
This PR adds a `redirect` query string when an unauthenticated user tries to access to protected routes.
In this way after the login action a user can be redirected there.

For example if `/profile` action is protected i.e. `nuxt.config.ts`

```ts
export default defineNuxtConfig({
  modules: ['@atlasconsulting/nuxt-bedita'],
  bedita: {
    auth: {
      rolesGuard: {
        '/profile': ['*'],
      },
    },
 }
})
```

When an unauthenticated  user got to `/profile` will be redirect to `/sign-in?redirect=/profile`.