### PR TITLE
feat: enable API proxy for POST, PATCH and DELETE methods

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -19,7 +19,13 @@ export default defineNuxtConfig({
     session: {
       name: '',
       secret: '',
-    }
+    },
+    proxyEndpoints: [
+      {
+        path: '/documents',
+        methods: ['*'],
+      },
+    ],
   },
   devtools: { enabled: true }
 })

--- a/playground/pages/api-proxy.vue
+++ b/playground/pages/api-proxy.vue
@@ -1,17 +1,110 @@
 <template>
   <div>
     <h2>BEdita API proxy Page</h2>
-    <p>List of BEdita objects:</p>
+
+    <form @submit.prevent="saveObj">
+      <input v-model="title" type="text" name="title" placeholder="Title">
+      <button type="submit">Create</button>
+    </form>
+
+    <p>List of BEdita documents:</p>
     <ul>
-      <li v-for="obj, key in data?.formattedData?.data" :key="key">{{ obj?.attributes?.title }}</li>
+      <li v-for="obj, key in docs" :key="key">
+        <span>{{ obj?.attributes?.title }}</span>
+        <button style="margin: 0 5px;" @click="editObject = obj">Edit</button>
+        <button @click="deleteObj(obj.id as string)"> X </button>
+      </li>
     </ul>
     {{ error }}
+
+    <div v-if="editObject">
+      <h3>Edit document</h3>
+      <form @submit.prevent="editObj">
+        <input type="text" name="title" :value="editObject?.attributes?.title">
+        <button type="submit">Save</button>
+      </form>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import type { JsonApiResourceObject } from '@atlasconsulting/bedita-sdk';
+import type { ApiResponseBodyResource } from '@atlasconsulting/nuxt-bedita';
 import type { ApiResponseBodyList } from '@atlasconsulting/nuxt-bedita';
 
-const { data, error } = useFetch<ApiResponseBodyList>('/api/bedita/objects');
+const title = ref('');
+const editObject = ref<JsonApiResourceObject>();
+const docs = ref<JsonApiResourceObject[]>();
 
+const { data, error } = await useFetch<ApiResponseBodyList>('/api/bedita/documents');
+docs.value = data.value?.formattedData?.data as JsonApiResourceObject[] || [];
+
+const saveObj = async () => {
+  try {
+    const response = await $fetch<ApiResponseBodyResource>('/api/bedita/documents', {
+      method: 'POST',
+      body: {
+        data: {
+          type: 'documents',
+          attributes: {
+            title: title.value,
+          },
+        },
+      }
+    });
+
+    title.value = '';
+
+    if (response.formattedData?.data) {
+      docs.value?.push(response.formattedData?.data as JsonApiResourceObject);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+const editObj = async (e: Event) => {
+  const form = e.currentTarget as HTMLFormElement;
+  const formData = new FormData(form);
+  try {
+    const response = await $fetch<ApiResponseBodyResource>(`/api/bedita/documents/${editObject.value?.id}`, {
+      method: 'PATCH',
+      body: {
+        data: {
+          id: editObject.value?.id,
+          type: editObject.value?.type,
+          attributes: {
+            title: formData.get('title'),
+          },
+        },
+      }
+    });
+
+    editObject.value = undefined;
+    form.reset();
+
+    if (response.formattedData?.data) {
+      docs.value = docs.value?.map((doc) => {
+        if (doc.id === response.formattedData?.data?.id) {
+          return response.formattedData?.data as JsonApiResourceObject;
+        }
+        return doc;
+      });
+    }
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+const deleteObj = async (id: string) => {
+  try {
+    await $fetch(`/api/bedita/documents/${id}`, {
+      method: 'DELETE',
+    });
+
+    docs.value = docs.value?.filter((obj: JsonApiResourceObject) => obj.id !== id) || [];
+  } catch (e) {
+    console.error(e);
+  }
+};
 </script>

--- a/src/module.ts
+++ b/src/module.ts
@@ -200,7 +200,19 @@ export default defineNuxtModule<ModuleOptions>({
       {
         route: '/api/bedita/**',
         handler: resolver.resolve('./runtime/server/api/bedita/api-proxy.get'),
-      }
+      },
+      {
+        route: '/api/bedita/**',
+        handler: resolver.resolve('./runtime/server/api/bedita/api-proxy.post'),
+      },
+      {
+        route: '/api/bedita/**',
+        handler: resolver.resolve('./runtime/server/api/bedita/api-proxy.patch'),
+      },
+      {
+        route: '/api/bedita/**',
+        handler: resolver.resolve('./runtime/server/api/bedita/api-proxy.delete'),
+      },
     );
 
     endpointsEnabled.forEach((endpoint) => {

--- a/src/runtime/server/api/bedita/api-proxy.delete.ts
+++ b/src/runtime/server/api/bedita/api-proxy.delete.ts
@@ -1,0 +1,13 @@
+import { defineEventHandler } from 'h3';
+import { apiProxyRequest } from '../../utils/api-proxy';
+import { handleBeditaApiError } from '../../utils/bedita-api-client';
+
+export default defineEventHandler(async (event) => {
+  try {
+    const response = await apiProxyRequest(event);
+
+    return response.data;
+  } catch (error) {
+    return handleBeditaApiError(event, error);
+  }
+});

--- a/src/runtime/server/api/bedita/api-proxy.patch.ts
+++ b/src/runtime/server/api/bedita/api-proxy.patch.ts
@@ -1,10 +1,10 @@
 import { defineEventHandler } from 'h3';
 import { apiProxyRequest } from '../../utils/api-proxy';
 import { handleBeditaApiError } from '../../utils/bedita-api-client';
-import type { ApiResponseBodyResource, ApiResponseBodyList } from '../../../types';
+import type { ApiResponseBodyResource } from '../../../types';
 import { type ApiResponseBodyError} from '@atlasconsulting/bedita-sdk';
 
-export default defineEventHandler(async (event): Promise<ApiResponseBodyResource | ApiResponseBodyList | Record<string, unknown> | ApiResponseBodyError> => {
+export default defineEventHandler(async (event): Promise<ApiResponseBodyResource | Record<string, unknown> | ApiResponseBodyError> => {
   try {
     const response = await apiProxyRequest(event);
 

--- a/src/runtime/server/api/bedita/api-proxy.post.ts
+++ b/src/runtime/server/api/bedita/api-proxy.post.ts
@@ -1,10 +1,10 @@
 import { defineEventHandler } from 'h3';
 import { apiProxyRequest } from '../../utils/api-proxy';
 import { handleBeditaApiError } from '../../utils/bedita-api-client';
-import type { ApiResponseBodyResource, ApiResponseBodyList } from '../../../types';
+import type { ApiResponseBodyResource } from '../../../types';
 import { type ApiResponseBodyError} from '@atlasconsulting/bedita-sdk';
 
-export default defineEventHandler(async (event): Promise<ApiResponseBodyResource | ApiResponseBodyList | Record<string, unknown> | ApiResponseBodyError> => {
+export default defineEventHandler(async (event): Promise<ApiResponseBodyResource | Record<string, unknown> | ApiResponseBodyError> => {
   try {
     const response = await apiProxyRequest(event);
 

--- a/src/runtime/server/utils/api-proxy.ts
+++ b/src/runtime/server/utils/api-proxy.ts
@@ -1,0 +1,69 @@
+import { useRuntimeConfig } from '#imports';
+import { H3Event, readBody, getQuery, getHeader, setResponseStatus, createError, assertMethod, type HTTPMethod } from 'h3';
+import type { ProxyEndpointConf } from '../../types';
+import { beditaApiClient } from './bedita-api-client';
+import type { BEditaClientRequestConfig } from '@atlasconsulting/bedita-sdk';
+
+const isEndpointAllowed = (path: string, method: HTTPMethod) => {
+  const config = useRuntimeConfig();
+  const allowedEndpoints: ProxyEndpointConf[] = (config.bedita.proxyEndpoints as ProxyEndpointConf[])
+    .filter((e: ProxyEndpointConf) => e.methods.includes('*') || e.methods.includes(method as 'GET' | 'POST' | 'PATCH' | 'DELETE'));
+
+  return allowedEndpoints.length && allowedEndpoints.filter(endpoint => endpoint.path === '*' || path.startsWith(endpoint.path)).length > 0;
+}
+
+/**
+ * Check if the requested API endpoint is allowed to be proxied and return the API path.
+ * If the endpoint is not allowed, an error is thrown.
+ */
+export const getBeditaApiPath = (event: H3Event): string => {
+  const apiMethods: Partial<HTTPMethod>[] = ['GET', 'POST', 'PATCH', 'DELETE'];
+  assertMethod(event, apiMethods);
+
+  const path = event.path.replace(/^\/api\/bedita/, '') || '';
+  if (isEndpointAllowed(path, event.method)) {
+    return path;
+  }
+
+  const otherMethods = apiMethods.filter(method => method !== event.method);
+  for (const method of otherMethods) {
+    if (isEndpointAllowed(path, method)) {
+      throw createError({
+        statusCode: 405,
+        statusMessage: 'Method Not Allowed',
+        message: `Method ${event.method} not allowed for the requested API endpoint.`
+      });
+    }
+  }
+
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Not Found',
+    message: 'API proxy endpoint not found'
+  });
+};
+
+/**
+ * Execute a proxy request to BEdita API.
+ */
+export const apiProxyRequest = async (event: H3Event) => {
+  const options: BEditaClientRequestConfig = {
+    url: getBeditaApiPath(event),
+    method: event.method.toLowerCase(),
+    params: getQuery(event),
+  };
+
+  if (event.method !== 'GET') {
+    options.data = await readBody(event);
+    options.headers = {
+      'Content-Type': getHeader(event, 'Content-Type'),
+      'Content-Length': getHeader(event, 'Content-Length'),
+    };
+  }
+
+  const client = await beditaApiClient(event);
+  const response = await client.request(options);
+  setResponseStatus(event, response.status);
+
+  return response;
+}


### PR DESCRIPTION
This PR resolves #17.

The configuration `proxyEndpoints` can be now used to allow API proxy for POST, PATCH and DELETE methods too.

For example setting in `nuxt.config.ts` under `bedita` key configuration

```ts
proxyEndpoints: [
  {
    path: '/documents',
    methods: ['POST', 'PATCH'],
  },
],
```

you can enable the app endpoints `POST /api/bedita/documents` and `PATCH /api/bedita/documents` as proxy to the related BEdita API endpoints.