### PR TITLE
feat: introduce roles guard middleware

### DIFF
--- a/playground/pages/admin.vue
+++ b/playground/pages/admin.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <h1>Admin page</h1>
+    <p>Congratulations! This page is only accessible by users with the role "admin".</p>
+    <div>
+      Your roles are:
+      <ul>
+        <li v-for="(role, index) in user.roles" :key="index">{{ role }}</li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  middleware: 'beditaRolesGuard',
+  beditaRolesGuard: {
+    roles: ['admin'],
+  },
+});
+
+const { user } = useBeditaAuth();
+</script>

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -9,6 +9,7 @@
       <li><NuxtLink to="/signup-activation">Signup Activation</NuxtLink></li>
       <li><NuxtLink to="/forgot-password">Forgot password</NuxtLink></li>
       <li><NuxtLink to="/profile">User profile</NuxtLink></li>
+      <li><NuxtLink to="/admin">Use of <code>beditaRolesGuard</code> middleware</NuxtLink></li>
       <li><NuxtLink to="/optout">Opt-out</NuxtLink></li>
       <li><NuxtLink to="/api-proxy">BEdita API proxy page</NuxtLink></li>
     </ul>

--- a/src/module.ts
+++ b/src/module.ts
@@ -232,6 +232,11 @@ export default defineNuxtModule<ModuleOptions>({
       path: resolver.resolve('./runtime/middleware/auth'),
       global: options.auth.global,
     });
+    addRouteMiddleware({
+      name: 'beditaRolesGuard',
+      path: resolver.resolve('./runtime/middleware/roles-guard'),
+      global: false,
+    });
 
     /*
      ********************************

--- a/src/runtime/middleware/roles-guard.ts
+++ b/src/runtime/middleware/roles-guard.ts
@@ -1,0 +1,40 @@
+import { defineNuxtRouteMiddleware, useRuntimeConfig, navigateTo, abortNavigation, createError } from '#imports';
+import { useBeditaAuth } from '../composables/useBeditaAuth';
+
+export default defineNuxtRouteMiddleware(async (to) => {
+  const config = useRuntimeConfig();
+  const { user, isLogged } = useBeditaAuth();
+
+  const redirectObject =  {
+    path: config.public.bedita.auth.unauthenticatedRedirect,
+    query: { redirect: to.fullPath },
+  };
+
+  // User must be logged
+  if (!isLogged.value) {
+    return navigateTo(redirectObject);
+  }
+
+  const allowedRoles = to?.meta?.beditaRolesGuard?.roles || [];
+  if (!Array.isArray(allowedRoles)) {
+    return abortNavigation(
+      createError({
+        statusCode: 500,
+        message: 'roles passed to beditaRolesGuard middleware must be an array',
+      })
+    );
+  }
+
+  // if user has at least a role present in allowedRoles, then user is authorized
+  // '*' means any role is authorized
+  if (allowedRoles.some(role => role === '*' || user.value?.roles.includes(role))) {
+    return;
+  }
+
+  return abortNavigation(
+    createError({
+      statusCode: 403,
+      message: 'Forbidden. You are not authorized to access this page.',
+    })
+  );
+});


### PR DESCRIPTION
This PR introduce a new middleware named `beditaRoutesMiddleware` useful to protect pages by user's roles.

Here is an example of use:

```vue
<script setup lang="ts">
definePageMeta({
  middleware: 'beditaRolesGuard',
  beditaRolesGuard: {
    roles: ['admin'],
  },
});
</script>
```

In this example the page will be protected and accessible only to users that have `admin` role.