### PR TITLE
feat: add replace translations configuration

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -33,6 +33,7 @@ export interface ModuleOptions {
     hideBadge?: boolean,
     useRecaptchaNet?: boolean,
   },
+  replaceTranslations?: boolean,
   resetPasswordPath?: string,
   session: {
     name: string,
@@ -65,6 +66,7 @@ export default defineNuxtModule<ModuleOptions>({
       hideBadge: false,
       useRecaptchaNet: false,
     },
+    replaceTranslations: false,
     resetPasswordPath: '/reset-password',
     session: {
       name: 'bedita',
@@ -83,6 +85,7 @@ export default defineNuxtModule<ModuleOptions>({
       apiKey: options.apiKey,
       proxyEndpoints: options.proxyEndpoints || [ { path: '*', methods: ['GET'] } ],
       recaptchaSecretKey: options.recaptcha.secretKey,
+      replaceTranslations: options.replaceTranslations,
       resetPasswordPath: options.resetPasswordPath,
       session: options.session,
     });

--- a/src/runtime/server/utils/bedita-api-client.ts
+++ b/src/runtime/server/utils/bedita-api-client.ts
@@ -1,6 +1,6 @@
-import { BEditaApiClient, MapIncludedInterceptor, type ApiResponseBodyError } from '@atlasconsulting/bedita-sdk';
+import { BEditaApiClient, MapIncludedInterceptor, type ApiResponseBodyError, type MapIncludedConfig } from '@atlasconsulting/bedita-sdk';
 import { AxiosError, isAxiosError } from 'axios';
-import { type H3Event, setResponseStatus, useSession, H3Error } from 'h3';
+import { type H3Event, setResponseStatus, useSession, H3Error, getQuery } from 'h3';
 import SessionStorageAdapter from '../services/adapters/session-storage-adapter';
 import { getSessionConfig } from './session';
 import { useRuntimeConfig } from '#imports';
@@ -13,7 +13,14 @@ export const beditaApiClient = async (event: H3Event): Promise<BEditaApiClient> 
     apiKey: config.bedita.apiKey,
     storageAdapter: new SessionStorageAdapter(session),
   });
-  client.addInterceptor(new MapIncludedInterceptor());
+
+  const options: MapIncludedConfig = {};
+  const lang = getQuery(event)?.lang;
+  if (config.bedita.replaceTranslations && lang) {
+    options.replaceWithTranslation = lang as string;
+  }
+
+  client.addInterceptor(new MapIncludedInterceptor(options));
 
   return client;
 };


### PR DESCRIPTION
This PR allows to configure the module to replace translated fields requested via BEdita API.

In `nuxt.config.ts`

```ts
export default defineNuxtConfig({
  modules: ['../src/module'],
  bedita: {
    replaceTranslations: true,
  }
}
```
After that, every API request with query string `lang` that involves BEdita objects will activate the replace of main fields with translated fields.

For example `/api/bedita/documents?lang=it`

