### PR TITLE
feat: support multi project switching client between them

### DIFF
--- a/src/runtime/server/api/bedita/_project.post.ts
+++ b/src/runtime/server/api/bedita/_project.post.ts
@@ -1,0 +1,20 @@
+import { defineEventHandler, useSession, readBody, setResponseStatus } from 'h3';
+import { getSessionConfig } from '../../utils/session';
+import { createError } from '#imports';
+
+export default defineEventHandler(async (event) => {
+  const session = await useSession(event, getSessionConfig());
+  const body = await readBody(event);
+  if (!body?.project || typeof body.project !== 'string') {
+    throw createError({
+      statusCode: 400,
+      statusMessage: '"project" must be a not empty string',
+    });
+  }
+
+  await session.update({ ...session.data, _project: body.project });
+
+  setResponseStatus(event, 204);
+
+  return {};
+});

--- a/src/runtime/server/utils/bedita-api-client.ts
+++ b/src/runtime/server/utils/bedita-api-client.ts
@@ -1,29 +1,40 @@
 import { BEditaApiClient, MapIncludedInterceptor, type ApiResponseBodyError, type MapIncludedConfig } from '@atlasconsulting/bedita-sdk';
 import type { AxiosError } from 'axios';
 import { isAxiosError } from 'axios';
-import { type H3Event, setResponseStatus, useSession, H3Error, getQuery } from 'h3';
+import { type H3Event, setResponseStatus, useSession, H3Error, getQuery, type SessionData } from 'h3';
+import { defu } from 'defu';
+import type { RuntimeConfig } from '@nuxt/schema';
 import SessionStorageAdapter from '../services/adapters/session-storage-adapter';
+import type { BeditaProjectConf } from '../../types';
 import { getSessionConfig } from './session';
 import { useRuntimeConfig } from '#imports';
 
 export const beditaApiClient = async (event: H3Event): Promise<BEditaApiClient> => {
-  const config = useRuntimeConfig();
+  const runtimeConfig = useRuntimeConfig();
   const session = await useSession(event, getSessionConfig());
+  const config = getProjectConfig(session.data, runtimeConfig) as BeditaProjectConf;
   const client = new BEditaApiClient({
-    baseUrl: config.bedita.apiBaseUrl,
-    apiKey: config.bedita.apiKey,
+    baseUrl: config?.apiBaseUrl as string,
+    apiKey: config?.apiKey as string,
     storageAdapter: new SessionStorageAdapter(session),
   });
 
   const options: MapIncludedConfig = {};
   const lang = getQuery(event)?.lang;
-  if (config.bedita.replaceTranslations && lang) {
+  if (config?.replaceTranslations && lang) {
     options.replaceWithTranslation = lang as string;
   }
 
   client.addInterceptor(new MapIncludedInterceptor(options));
 
   return client;
+};
+
+export const getProjectConfig = (sessionData: SessionData, config: RuntimeConfig, property?: keyof BeditaProjectConf) => {
+  const projectConfig = (config.bedita?.projects?.[sessionData?._project] || {}) as BeditaProjectConf;
+  const beditaConfig = defu(projectConfig, config.bedita);
+
+  return property ? beditaConfig?.[property] : beditaConfig;
 };
 
 export const handleBeditaApiError = async (event: H3Event, error: AxiosError | H3Error | any): Promise<ApiResponseBodyError> => {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -49,3 +49,38 @@ export type ProxyEndpointConf = {
   path: string;
   methods: ('GET' | 'POST' | 'PATCH' | 'DELETE' | '*')[];
 };
+
+export type BeditaProjectConf = {
+  apiBaseUrl: string;
+  apiKey: string;
+  replaceTranslations?: boolean;
+};
+
+export interface BeditaModuleOptions {
+  apiBaseUrl: string;
+  apiKey: string;
+  projects?: Record<string, BeditaProjectConf>;
+  auth: {
+    global?: boolean;
+    required?: boolean;
+    unauthenticatedRedirect?: string;
+    publicRoutes?: string[];
+    rolesGuard?: Record<string, string[]>;
+    sessionUserProps?: string[];
+  };
+  endpoints?: EndpointConf[];
+  proxyEndpoints?: ProxyEndpointConf[];
+  recaptcha: {
+    enabled: boolean;
+    siteKey?: string;
+    secretKey?: string;
+    hideBadge?: boolean;
+    useRecaptchaNet?: boolean;
+  };
+  replaceTranslations?: boolean;
+  resetPasswordPath?: string;
+  session: {
+    name: string;
+    secret: string;
+  };
+};


### PR DESCRIPTION
This PR introduce the ability to switch between BEdita API projects. 

**:warning: Warning**

At the moment this feature is intended for dynamic uses of one API at the time