### PR TITLE
!refactor: pass event to useRuntimeConfig() in server side

### DIFF
--- a/docs/content/2.features/1.server-api.md
+++ b/docs/content/2.features/1.server-api.md
@@ -67,34 +67,34 @@ Return the configuration properties reading merged from current project and core
 
 ### `recaptchaVerifyToken`
 
-`recaptchaVerifyToken(token: string, action: string, throwError = true): Promise<boolean>`{lang=ts}
+`recaptchaVerifyToken(event: H3Event, token: string, action: string, throwError = true): Promise<boolean>`{lang=ts}
 
 It needs to verify recapctha token sent by client. By default it throws a `400 Bad Request` if token validation fails.
 
 ```ts [/server/api/example.ts]
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
-  await recaptchaVerifyToken(body?.recaptcha_token, 'my-action');
+  await recaptchaVerifyToken(event, body?.recaptcha_token, 'my-action');
   // do other stuff
 });
 ```
 
 ### `getSessionConfig`
 
-`getSessionConfig(): SessionConfig`{lang=ts}
+`getSessionConfig(event: H3Event): SessionConfig`{lang=ts}
 
 Get the actual session configuration. It is useful to retrieve session.
 
 ```ts [/server/api/example.ts]
 export default defineEventHandler(async (event) => {
-  const session = await useSession(event, getSessionConfig());
+  const session = await useSession(event, getSessionConfig(event));
   // do stuff with session
 });
 ```
 
 ### `filterUserDataToStore`
 
-`filterUserDataToStore(data: UserAuth): UserDataStore`{lang=ts}
+`filterUserDataToStore(data: UserAuth, event?: H3Event): UserDataStore`{lang=ts}
 
 Filter user data and return a minimum data. Used to store in session cookie a miminal set of data.
 
@@ -104,7 +104,7 @@ export default defineEventHandler(async (event) => {
     const client = await beditaApiClient(event);
     const response = await client.get('/auth/user');
 
-    return filterUserDataToStore(response?.data);
+    return filterUserDataToStore(response?.data, event);
   } catch (error) {
     return handleBeditaApiError(event, error);
   }

--- a/docs/content/2.features/3.composables.md
+++ b/docs/content/2.features/3.composables.md
@@ -295,7 +295,7 @@ const { pending, error } = await signupActivation();
 `useBeditaRecaptcha()`{lang=ts} gives access to [reCAPTCHA v3](https://developers.google.com/recaptcha/docs/v3) to protect forms.
 
 ::alert{type="warning"}
-It should be used in conjunction with server side function `recaptchaVerifyToken(token: string, action: string, throwError = true)`{lang=ts}.
+It should be used in conjunction with server side function `recaptchaVerifyToken(event: H3Event, token: string, action: string, throwError = true)`{lang=ts}.
 ::
 
 ### `executeRecaptcha`

--- a/playground/middleware/project.global.ts
+++ b/playground/middleware/project.global.ts
@@ -4,7 +4,7 @@ export default defineNuxtRouteMiddleware(async () => {
   if (import.meta.server) {
     const event: H3Event = useRequestEvent() as H3Event;
     const currentProject = useState('currentProject', () => '');
-    const session = await useSession(event, getSessionConfig());
+    const session = await useSession(event, getSessionConfig(event));
     if (session.data?._project) {
       currentProject.value = session.data._project;
     }

--- a/playground/pages/api-proxy.vue
+++ b/playground/pages/api-proxy.vue
@@ -35,6 +35,7 @@
           <a :href="file?.meta?.media_url" target="_blank">{{ file?.attributes?.title }}</a>
         </li>
       </ul>
+      {{ errorFile }}
     </div>
   </div>
 </template>
@@ -50,6 +51,9 @@ const files = ref<JsonApiResourceObject[]>([]);
 
 const { data, error } = await useFetch<ApiResponseBodyList>('/api/bedita/documents');
 docs.value = data.value?.formattedData?.data as JsonApiResourceObject[] || [];
+
+const { data: filedata, error: errorFile } = await useFetch<ApiResponseBodyList>('/api/bedita/files');
+files.value = filedata.value?.formattedData?.data as JsonApiResourceObject[] || [];
 
 const saveObj = async () => {
   try {

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -5,9 +5,11 @@ import { useBeditaAuth } from '../composables/useBeditaAuth';
 import { defineNuxtRouteMiddleware, useRequestEvent, useRuntimeConfig, navigateTo, abortNavigation, createError } from '#imports';
 
 export default defineNuxtRouteMiddleware(async (to) => {
+  let config = useRuntimeConfig();
   // SERVER SIDE: set user state from session data
   if (import.meta.server) {
     const event = useRequestEvent();
+    config = useRuntimeConfig(event); // ensure to pass event server side
     const client = await beditaApiClient(event);
     const userData: UserDataStore | null = await client.getStorageService().get('user');
 
@@ -16,8 +18,6 @@ export default defineNuxtRouteMiddleware(async (to) => {
       user.value = userData;
     }
   }
-
-  const config = useRuntimeConfig();
 
   // public routes are always accessible
   if (config.public.bedita.auth.publicRoutes.includes(to.path)) {

--- a/src/runtime/middleware/roles-guard.ts
+++ b/src/runtime/middleware/roles-guard.ts
@@ -1,8 +1,8 @@
 import { useBeditaAuth } from '../composables/useBeditaAuth';
-import { defineNuxtRouteMiddleware, useRuntimeConfig, navigateTo, abortNavigation, createError } from '#imports';
+import { defineNuxtRouteMiddleware, useRuntimeConfig, useRequestEvent, navigateTo, abortNavigation, createError } from '#imports';
 
 export default defineNuxtRouteMiddleware(async (to) => {
-  const config = useRuntimeConfig();
+  const config = import.meta.server ? useRuntimeConfig(useRequestEvent()) : useRuntimeConfig();
   const { user, isLogged } = useBeditaAuth();
 
   const redirectObject = {

--- a/src/runtime/server/api/bedita/_project.post.ts
+++ b/src/runtime/server/api/bedita/_project.post.ts
@@ -3,7 +3,7 @@ import { getSessionConfig } from '../../utils/session';
 import { createError } from '#imports';
 
 export default defineEventHandler(async (event) => {
-  const session = await useSession(event, getSessionConfig());
+  const session = await useSession(event, getSessionConfig(event));
   const body = await readBody(event);
   if (!body?.project || typeof body.project !== 'string') {
     throw createError({

--- a/src/runtime/server/api/bedita/auth/change.patch.ts
+++ b/src/runtime/server/api/bedita/auth/change.patch.ts
@@ -9,7 +9,7 @@ import { filterUserDataToStore } from '../../../../utils/user-data-store';
 export default defineEventHandler(async (event) => {
   try {
     const body = await readBody(event);
-    await recaptchaVerifyToken(body?.recaptcha_token, RecaptchaActions.CHANGE_PASSWORD);
+    await recaptchaVerifyToken(event, body?.recaptcha_token, RecaptchaActions.CHANGE_PASSWORD);
     const client = await beditaApiClient(event);
     const payload = {
       uuid: body?.uuid,
@@ -26,7 +26,7 @@ export default defineEventHandler(async (event) => {
       const storageService = client.getStorageService();
       await storageService.setAccessToken(response.data?.meta?.jwt);
       await storageService.setRefreshToken(response.data?.meta?.renew);
-      await storageService.set('user', filterUserDataToStore(response?.formattedData));
+      await storageService.set('user', filterUserDataToStore(response?.formattedData, event));
     }
 
     return response.formattedData as UserAuth;

--- a/src/runtime/server/api/bedita/auth/login.post.ts
+++ b/src/runtime/server/api/bedita/auth/login.post.ts
@@ -9,14 +9,14 @@ import { RecaptchaActions } from '../../../../utils/recaptcha-helpers';
 export default defineEventHandler(async (event) => {
   try {
     const body = await readBody(event);
-    await recaptchaVerifyToken(body?.recaptcha_token, RecaptchaActions.LOGIN);
+    await recaptchaVerifyToken(event, body?.recaptcha_token, RecaptchaActions.LOGIN);
     const client = await beditaApiClient(event);
     await client.authenticate(body?.username, body?.password);
     const response = await client.get('/auth/user', {
       responseInterceptors: [new FormatUserInterceptor(client)],
     });
 
-    await client.getStorageService().set('user', filterUserDataToStore(response?.formattedData));
+    await client.getStorageService().set('user', filterUserDataToStore(response?.formattedData, event));
 
     return response?.formattedData as UserAuth;
   } catch (error) {

--- a/src/runtime/server/api/bedita/auth/logout.ts
+++ b/src/runtime/server/api/bedita/auth/logout.ts
@@ -2,7 +2,7 @@ import { setResponseStatus, defineEventHandler, useSession } from 'h3';
 import { getSessionConfig } from '../../../utils/session';
 
 export default defineEventHandler(async (event) => {
-  const session = await useSession(event, getSessionConfig());
+  const session = await useSession(event, getSessionConfig(event));
   await session.clear();
 
   setResponseStatus(event, 204);

--- a/src/runtime/server/api/bedita/auth/optout.post.ts
+++ b/src/runtime/server/api/bedita/auth/optout.post.ts
@@ -6,7 +6,7 @@ import { RecaptchaActions } from '../../../../utils/recaptcha-helpers';
 export default defineEventHandler(async (event) => {
   try {
     const body = await readBody(event);
-    await recaptchaVerifyToken(body.recaptcha_token, RecaptchaActions.OPTOUT);
+    await recaptchaVerifyToken(event, body.recaptcha_token, RecaptchaActions.OPTOUT);
     const client = await beditaApiClient(event);
     const response = await client.post('/auth/optout', {
       username: body.username,

--- a/src/runtime/server/api/bedita/auth/reset.post.ts
+++ b/src/runtime/server/api/bedita/auth/reset.post.ts
@@ -6,10 +6,10 @@ import { useRuntimeConfig } from '#imports';
 
 export default defineEventHandler(async (event) => {
   try {
-    const runtimeConfig = useRuntimeConfig();
+    const runtimeConfig = useRuntimeConfig(event);
     const resetUrl = `${getRequestURL(event).origin}${runtimeConfig.bedita.resetPasswordPath}`;
     const body = await readBody(event);
-    await recaptchaVerifyToken(body?.recaptcha_token, RecaptchaActions.RESET_PASSWORD);
+    await recaptchaVerifyToken(event, body?.recaptcha_token, RecaptchaActions.RESET_PASSWORD);
     const client = await beditaApiClient(event);
     await client.post('/auth/change', {
       contact: body?.contact,

--- a/src/runtime/server/api/bedita/auth/user.patch.ts
+++ b/src/runtime/server/api/bedita/auth/user.patch.ts
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => {
       responseInterceptors: [new FormatUserInterceptor(client)],
     };
     const response = await client.patch('/auth/user', body, requestConfig);
-    await client.getStorageService().set('user', filterUserDataToStore(response?.formattedData));
+    await client.getStorageService().set('user', filterUserDataToStore(response?.formattedData, event));
 
     return response?.formattedData as UserAuth;
   } catch (error) {

--- a/src/runtime/server/api/bedita/signup/signup.post.ts
+++ b/src/runtime/server/api/bedita/signup/signup.post.ts
@@ -8,7 +8,7 @@ export default defineEventHandler(async (event): Promise<JsonApiResourceObject |
   try {
     const body = await readBody(event);
 
-    await recaptchaVerifyToken(body?.recaptcha_token, RecaptchaActions.SIGNUP);
+    await recaptchaVerifyToken(event, body?.recaptcha_token, RecaptchaActions.SIGNUP);
     const client = await beditaApiClient(event);
     const response = await client.post('/signup', body);
 

--- a/src/runtime/server/utils/api-proxy.ts
+++ b/src/runtime/server/utils/api-proxy.ts
@@ -4,8 +4,8 @@ import type { ProxyEndpointConf } from '../../types';
 import { beditaApiClient } from './bedita-api-client';
 import { useRuntimeConfig } from '#imports';
 
-const isEndpointAllowed = (path: string, method: HTTPMethod) => {
-  const config = useRuntimeConfig();
+const isEndpointAllowed = (event: H3Event, path: string, method: HTTPMethod) => {
+  const config = useRuntimeConfig(event);
   const allowedEndpoints: ProxyEndpointConf[] = (config.bedita.proxyEndpoints as ProxyEndpointConf[])
     .filter((e: ProxyEndpointConf) => e.methods.includes('*') || e.methods.includes(method as 'GET' | 'POST' | 'PATCH' | 'DELETE'));
 
@@ -21,13 +21,13 @@ export const getBeditaApiPath = (event: H3Event): string => {
   assertMethod(event, apiMethods);
 
   const path = event.path.replace(/^\/api\/bedita/, '') || '';
-  if (isEndpointAllowed(path, event.method)) {
+  if (isEndpointAllowed(event, path, event.method)) {
     return path;
   }
 
   const otherMethods = apiMethods.filter(method => method !== event.method);
   for (const method of otherMethods) {
-    if (isEndpointAllowed(path, method)) {
+    if (isEndpointAllowed(event, path, method)) {
       throw createError({
         statusCode: 405,
         statusMessage: 'Method Not Allowed',

--- a/src/runtime/server/utils/bedita-api-client.ts
+++ b/src/runtime/server/utils/bedita-api-client.ts
@@ -10,8 +10,8 @@ import { getSessionConfig } from './session';
 import { useRuntimeConfig } from '#imports';
 
 export const beditaApiClient = async (event: H3Event): Promise<BEditaApiClient> => {
-  const runtimeConfig = useRuntimeConfig();
-  const session = await useSession(event, getSessionConfig());
+  const runtimeConfig = useRuntimeConfig(event);
+  const session = await useSession(event, getSessionConfig(event));
   const config = getProjectConfig(session.data, runtimeConfig) as BeditaProjectConf;
   const client = new BEditaApiClient({
     baseUrl: config?.apiBaseUrl as string,

--- a/src/runtime/server/utils/recaptcha.ts
+++ b/src/runtime/server/utils/recaptcha.ts
@@ -1,15 +1,15 @@
-import { createError } from 'h3';
+import { type H3Event, createError } from 'h3';
 import { ofetch } from 'ofetch';
 import { isRecaptchaEnabled } from '../../utils/recaptcha-helpers';
 import type { RecaptchaResponse } from '../../types';
 import { useRuntimeConfig } from '#imports';
 
-export const recaptchaVerifyToken = async (token: string, action: string, throwError = true): Promise<boolean> => {
-  if (!isRecaptchaEnabled()) {
+export const recaptchaVerifyToken = async (event: H3Event, token: string, action: string, throwError = true): Promise<boolean> => {
+  if (!isRecaptchaEnabled(event)) {
     return true;
   }
 
-  const config = useRuntimeConfig();
+  const config = useRuntimeConfig(event);
   const data: RecaptchaResponse = await ofetch('https://www.google.com/recaptcha/api/siteverify', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -1,8 +1,8 @@
-import type { SessionConfig } from 'h3';
+import type { H3Event, SessionConfig } from 'h3';
 import { useRuntimeConfig } from '#imports';
 
-export const getSessionConfig = (): SessionConfig => {
-  const config = useRuntimeConfig();
+export const getSessionConfig = (event: H3Event): SessionConfig => {
+  const config = useRuntimeConfig(event);
 
   return {
     password: config.bedita.session.secret,

--- a/src/runtime/utils/recaptcha-helpers.ts
+++ b/src/runtime/utils/recaptcha-helpers.ts
@@ -1,3 +1,4 @@
+import type { H3Event } from 'h3';
 import { useRuntimeConfig } from '#imports';
 
 export const RecaptchaActions = {
@@ -8,6 +9,6 @@ export const RecaptchaActions = {
   OPTOUT: 'optout',
 } as const;
 
-export const isRecaptchaEnabled = () => {
-  return !!useRuntimeConfig().public.recaptcha.enabled === true;
+export const isRecaptchaEnabled = (event?: H3Event) => {
+  return !!useRuntimeConfig(event).public.recaptcha.enabled === true;
 };

--- a/src/runtime/utils/user-data-store.ts
+++ b/src/runtime/utils/user-data-store.ts
@@ -1,7 +1,8 @@
+import type { H3Event } from 'h3';
 import type { UserAuth, UserDataStore } from '../types';
 import { useRuntimeConfig } from '#imports';
 
-export const filterUserDataToStore = (data: UserAuth): UserDataStore => {
+export const filterUserDataToStore = (data: UserAuth, event?: H3Event): UserDataStore => {
   const userData: UserDataStore = {
     id: data?.data?.id,
     name: data?.data?.attributes?.name || null,
@@ -10,7 +11,7 @@ export const filterUserDataToStore = (data: UserAuth): UserDataStore => {
     email: data?.data?.attributes?.email || null,
     roles: data?.roles || [],
   };
-  for (const prop of useRuntimeConfig().public.bedita.auth?.sessionUserProps || []) {
+  for (const prop of useRuntimeConfig(event).public.bedita.auth?.sessionUserProps || []) {
     userData[prop] = data?.data?.attributes?.[prop] || data?.data?.meta?.[prop] || null;
   }
 


### PR DESCRIPTION
This PR improves the use of `useRuntimeConfig()` composable in server side passing the `event: H3Event` when possible.

The Nuxt documentation says:

> Giving the event as argument to useRuntimeConfig is optional, but it is recommended to pass it to get the runtime config overwritten by [environment variables](https://nuxt.com/docs/guide/going-further/runtime-config#environment-variables) at runtime for server routes.

Since passing event changes some functions signature, this is a **breaking change**.