### PR TITLE
feat!: Allow to configure proxy endpoints with regexp

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -228,7 +228,7 @@ projects: Record &lt;string, BeditaProjectConf&gt;
 
 Use this property to enable/disable API proxy to BEdita API. It is configurable per endpoint.
 
-By default all `GET` requests are proxied to BEdita API (if not found in routing context), for example a request in the app to `/api/bedita/documents` will be proxied to `GET /documents` BEdita API.
+By default all `GET` requests at `/api/bedita` except `/api/bedita/users` and `/api/bedita/profiles` are proxied to BEdita API (if not found in routing context), for example a request in the app to `/api/bedita/documents` will be proxied to `GET /documents` BEdita API.
 
 It is possible to limit the requests proxied defining the endpoints allowed.
 For example the following configuration enable `GET /api/bedita/events` and `GET /api/bedita/news` while other `GET /api/bedita/<other-bedita-endpoint>` request will return a `404 Not Found`.
@@ -253,6 +253,29 @@ export default defineNuxtConfig({
 })
 ```
 
+Another way is using the option `regExp` to define a regular expression to test the URL path.
+The example below is equivalent to that above:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: [
+    '@atlasconsulting/nuxt-bedita',
+  ],
+  bedita: {
+    proxyEndpoints: [
+      {
+        regExp: '^/(events|news).*$',
+        methods: ['GET'],
+      },
+    ],
+  },
+})
+```
+
+::alert{type="warning"}
+Take care that the value of `regExp` **must be a string** as you would pass to [`RegExp()` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp).
+::
+
 <table>
   <thead>
     <tr>
@@ -269,7 +292,7 @@ export default defineNuxtConfig({
         <pre>
 proxyEndpoints: [
   {
-    path: '*', // all endpoints allowed
+    regExp: '^/(?!users|profiles).*$', // all endpoints except `users` and `profiles` are allowed
     methods: ['GET'], // HTTP methods allowed
   },
 ]

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -34,7 +34,7 @@ export default defineNuxtConfig({
     },
     proxyEndpoints: [
       {
-        path: '*',
+        regExp: '^/(?!users|profiles).*$',
         methods: ['GET'],
       },
       {

--- a/src/module.ts
+++ b/src/module.ts
@@ -57,7 +57,7 @@ export default defineNuxtModule<BeditaModuleOptions>({
       apiBaseUrl: options.apiBaseUrl,
       apiKey: options.apiKey,
       projects: options?.projects || null,
-      proxyEndpoints: options.proxyEndpoints || [{ path: '*', methods: ['GET'] }],
+      proxyEndpoints: options.proxyEndpoints || [{ regExp: '^/(?!users|profiles).*$', methods: ['GET'] }],
       recaptchaSecretKey: options.recaptcha.secretKey,
       replaceTranslations: options.replaceTranslations,
       resetPasswordPath: options.resetPasswordPath,

--- a/src/runtime/server/utils/api-proxy.ts
+++ b/src/runtime/server/utils/api-proxy.ts
@@ -10,11 +10,11 @@ const isEndpointAllowed = (event: H3Event, path: string, method: HTTPMethod) => 
     .filter((e: ProxyEndpointConf) => e.methods.includes('*') || e.methods.includes(method as 'GET' | 'POST' | 'PATCH' | 'DELETE'));
 
   return allowedEndpoints.length && allowedEndpoints.filter((endpoint) => {
-    if (endpoint.path) {
+    if (endpoint?.path) {
       return endpoint.path === '*' || path.startsWith(endpoint.path);
     }
 
-    if (endpoint.regExp) {
+    if (endpoint?.regExp) {
       return new RegExp(endpoint.regExp).test(path);
     }
 

--- a/src/runtime/server/utils/api-proxy.ts
+++ b/src/runtime/server/utils/api-proxy.ts
@@ -9,7 +9,17 @@ const isEndpointAllowed = (event: H3Event, path: string, method: HTTPMethod) => 
   const allowedEndpoints: ProxyEndpointConf[] = (config.bedita.proxyEndpoints as ProxyEndpointConf[])
     .filter((e: ProxyEndpointConf) => e.methods.includes('*') || e.methods.includes(method as 'GET' | 'POST' | 'PATCH' | 'DELETE'));
 
-  return allowedEndpoints.length && allowedEndpoints.filter(endpoint => endpoint.path === '*' || path.startsWith(endpoint.path)).length > 0;
+  return allowedEndpoints.length && allowedEndpoints.filter((endpoint) => {
+    if (endpoint.path) {
+      return endpoint.path === '*' || path.startsWith(endpoint.path);
+    }
+
+    if (endpoint.regExp) {
+      return new RegExp(endpoint.regExp).test(path);
+    }
+
+    return false;
+  }).length > 0;
 };
 
 /**
@@ -39,7 +49,7 @@ export const getBeditaApiPath = (event: H3Event): string => {
   throw createError({
     statusCode: 404,
     statusMessage: 'Not Found',
-    message: 'API proxy endpoint not found',
+    message: 'API endpoint not found',
   });
 };
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -46,7 +46,8 @@ export type SignupBeditaBody = {
 export type EndpointConf = 'auth' | 'signup';
 
 export type ProxyEndpointConf = {
-  path: string;
+  path?: string;
+  regExp?: string;
   methods: ('GET' | 'POST' | 'PATCH' | 'DELETE' | '*')[];
 };
 


### PR DESCRIPTION
This PR introduces `regExp` as configuration option for  proxy endpoints.

#### BREAKING CHANGES

The default proxy endpoints configuration now enables all `GET` requests but `/users` and `/profiles`.
To restore the old configuration you can edit the app `nuxt.config.ts` as

```ts
bedita: {
  proxyEndpoints: [
      {
        'path': '*',
        'methods':  ['GET']
      }
  ]
}