### PR TITLE
fix: API proxy to set Accept header only if not contain "*/*"

### DIFF
--- a/src/runtime/server/utils/api-proxy.ts
+++ b/src/runtime/server/utils/api-proxy.ts
@@ -74,7 +74,7 @@ export const apiProxyRequest = async (event: H3Event) => {
 
   // add Accept header only if specified by client
   const accept = getHeader(event, 'Accept');
-  if (accept && accept !== '*/*') {
+  if (accept && accept.search(/\*\/\*/) === -1) {
     options.headers = {
       ...(options.headers || {}),
       Accept: accept,


### PR DESCRIPTION
This improve the way proxying API choose to set `Accept` header.
Before this PR the `Accept` header was set for API client only if it was stricly different from `*/*`.
After this PR  the `Accept` header was set for API client only if it doesn't contain `*/*`.